### PR TITLE
Apply brand color to CTAs

### DIFF
--- a/src/components/AdvisorForm/AdvisorForm.tsx
+++ b/src/components/AdvisorForm/AdvisorForm.tsx
@@ -306,7 +306,7 @@ const AdvisorForm: React.FC<AdvisorFormProps> = ({ visible }) => {
                   <div className={`ml-auto ${currentStep === 1 ? 'w-full' : ''}`}>
                     <button
                       onClick={handleNext}
-                      className={`py-3 px-6 bg-primary-700 hover:bg-primary-800 text-white font-semibold rounded-lg transition duration-300 flex items-center justify-center ${
+                      className={`cta-button py-3 px-6 flex items-center justify-center ${
                         currentStep === 1 ? 'w-full' : ''
                       }`}
                     >

--- a/src/components/AdvisorForm/steps/SuccessScreen.tsx
+++ b/src/components/AdvisorForm/steps/SuccessScreen.tsx
@@ -40,14 +40,14 @@ const SuccessScreen: React.FC = () => {
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-8">
             <a
               href="#"
-              className="py-3 px-6 bg-primary-700 hover:bg-primary-800 text-white font-semibold rounded-lg transition duration-300 shadow-md flex items-center justify-center"
+              className="cta-button py-3 px-6 flex items-center justify-center"
             >
               <Calendar className="mr-2 h-5 w-5" />
               Schedule a Consultation
             </a>
             <a
               href="#"
-              className="py-3 px-6 border border-primary-600 text-primary-700 font-semibold rounded-lg hover:bg-primary-50 transition duration-300"
+              className="py-3 px-6 border border-brand text-brand font-semibold rounded-lg hover:bg-brand/10 transition duration-300"
             >
               Learn More About Our Process
             </a>

--- a/src/components/CtaBanner.tsx
+++ b/src/components/CtaBanner.tsx
@@ -35,7 +35,7 @@ const CtaBanner: React.FC<CtaBannerProps> = ({ onFindAdvisorClick }) => {
           </p>
           <button
             onClick={onFindAdvisorClick}
-            className="py-4 px-8 bg-accent-500 hover:bg-accent-600 text-white font-semibold rounded-lg transition duration-300 shadow-md inline-flex items-center group"
+            className="cta-button py-4 px-8 inline-flex items-center group"
           >
             Get Matched Now
             <ArrowRight className="ml-2 h-5 w-5 transition-transform duration-300 group-hover:translate-x-1" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,41 +36,39 @@ const Header: React.FC<HeaderProps> = ({ onFindAdvisorClick }) => {
       <div className="container mx-auto px-4 lg:px-8">
         <div className="flex items-center justify-between">
           <div className="flex items-center">
-            <DollarSign className="h-8 w-8 text-primary-700" />
-            <span className="ml-2 text-xl font-serif font-bold text-primary-800">FinancialAdvisor.net</span>
+            <DollarSign className="h-8 w-8 text-brand" />
+            <span className="ml-2 text-xl font-serif font-bold text-brand">FinancialAdvisor.net</span>
           </div>
           
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-8">
             <button 
               onClick={() => scrollToSection('why-advisor')} 
-              className="text-secondary-700 hover:text-primary-700 font-medium transition duration-300"
+              className="text-secondary-700 hover:text-brand font-medium transition duration-300"
             >
               Why an Advisor
             </button>
             <button 
               onClick={() => scrollToSection('advisor-value')} 
-              className="text-secondary-700 hover:text-primary-700 font-medium transition duration-300"
+              className="text-secondary-700 hover:text-brand font-medium transition duration-300"
             >
               Benefits
             </button>
             <button 
               onClick={() => scrollToSection('how-it-works')} 
-              className="text-secondary-700 hover:text-primary-700 font-medium transition duration-300"
+              className="text-secondary-700 hover:text-brand font-medium transition duration-300"
             >
               How It Works
             </button>
             <button 
               onClick={() => scrollToSection('faqs')} 
-              className="text-secondary-700 hover:text-primary-700 font-medium transition duration-300"
+              className="text-secondary-700 hover:text-brand font-medium transition duration-300"
             >
               FAQs
             </button>
             <button
               onClick={onFindAdvisorClick}
-              className={`py-2 px-5 ${
-                isScrolled ? 'bg-primary-700 hover:bg-primary-800' : 'bg-accent-500 hover:bg-accent-600'
-              } text-white font-semibold rounded-lg transition duration-300 shadow-sm`}
+              className="cta-button py-2 px-5 shadow-sm"
             >
               Find My Advisor
             </button>
@@ -80,7 +78,7 @@ const Header: React.FC<HeaderProps> = ({ onFindAdvisorClick }) => {
           <div className="flex md:hidden">
             <button
               onClick={onFindAdvisorClick}
-              className="mr-4 py-2 px-4 bg-accent-500 hover:bg-accent-600 text-white font-semibold rounded-lg transition duration-300 shadow-sm text-sm"
+              className="cta-button mr-4 py-2 px-4 text-sm shadow-sm"
             >
               Find Advisor
             </button>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -34,14 +34,14 @@ const Hero: React.FC<HeroProps> = ({ onFindAdvisorClick }) => {
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
               <button
                 onClick={onFindAdvisorClick}
-                className="py-4 px-8 bg-accent-500 hover:bg-accent-600 text-white font-semibold rounded-lg transition duration-300 shadow-md flex items-center justify-center group"
+                className="cta-button py-4 px-8 flex items-center justify-center group"
               >
                 Find My Financial Advisor
                 <ArrowRight className="ml-2 h-5 w-5 transition-transform duration-300 group-hover:translate-x-1" />
               </button>
               <button
                 onClick={() => document.getElementById('why-advisor')?.scrollIntoView({ behavior: 'smooth' })}
-                className="py-4 px-8 border border-primary-500 text-primary-700 font-semibold rounded-lg hover:bg-primary-50 transition duration-300"
+                className="py-4 px-8 border border-brand text-brand font-semibold rounded-lg hover:bg-brand/10 transition duration-300"
               >
                 Learn More
               </button>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -29,7 +29,7 @@ const ScrollToTop: React.FC = () => {
       {isVisible && (
         <button
           onClick={scrollToTop}
-          className="fixed bottom-24 right-6 md:bottom-8 md:right-8 p-3 bg-primary-700 hover:bg-primary-800 text-white rounded-full shadow-lg transition-all duration-300 animate-fade-in z-40 focus:outline-none"
+          className="fixed bottom-24 right-6 md:bottom-8 md:right-8 p-3 bg-brand hover:bg-brand-dark text-white rounded-full shadow-lg transition-all duration-300 animate-fade-in z-40 focus:outline-none"
           aria-label="Scroll to top"
         >
           <ChevronUp className="h-5 w-5" />

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,23 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply text-brand;
+  }
+}
+
+@layer components {
+  .cta-button {
+    @apply bg-brand text-white font-semibold rounded-lg transition duration-300 shadow-md;
+  }
+  .cta-button:hover {
+    @apply bg-brand-dark;
+  }
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -57,7 +57,7 @@ const Home: React.FC = () => {
         <div className="fixed bottom-0 left-0 right-0 p-4 bg-white bg-opacity-95 shadow-lg border-t border-gray-200 md:hidden animate-fade-in z-50">
           <button
             onClick={handleFindAdvisorClick}
-            className="w-full py-4 px-6 bg-accent-500 hover:bg-accent-600 text-white font-semibold rounded-lg transition duration-300 shadow-md flex items-center justify-center"
+            className="cta-button w-full py-4 px-6 flex items-center justify-center"
           >
             Find My Financial Advisor
           </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,10 @@ export default {
   theme: {
     extend: {
       colors: {
+        brand: {
+          DEFAULT: '#37628b',
+          dark: '#2c4f73',
+        },
         primary: {
           50: '#f0f7ff',
           100: '#e0eefe',
@@ -13,8 +17,8 @@ export default {
           500: '#0c90e6',
           600: '#0073c4',
           700: '#015b9e',
-          800: '#054d83',
-          900: '#0a416e',
+          800: '#37628b',
+          900: '#37628b',
           950: '#062a4b',
         },
         secondary: {


### PR DESCRIPTION
## Summary
- define `brand` color palette in Tailwind config
- change `primary-800` and `primary-900` to brand color
- add utility styles for headings and CTA buttons
- update CTA buttons across components to use new class
- update header links and icons to match brand color
- recolor scroll-to-top button
- ensure floating CTA and success screen use brand styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684047e50d6c832eb37308529faef1ca