### PR TITLE
Enable multi-select reason step and auto-scroll

### DIFF
--- a/src/components/AdvisorForm/AdvisorForm.tsx
+++ b/src/components/AdvisorForm/AdvisorForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { ChevronRight, ChevronLeft } from 'lucide-react';
 import { useInView } from 'react-intersection-observer';
 import Step1ZipCode from './steps/Step1ZipCode';
@@ -28,6 +28,7 @@ const AdvisorForm: React.FC<AdvisorFormProps> = ({ visible }) => {
     triggerOnce: true,
     threshold: 0.1,
   });
+  const formRef = useRef<HTMLDivElement | null>(null);
 
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState<FormData>({
@@ -39,7 +40,7 @@ const AdvisorForm: React.FC<AdvisorFormProps> = ({ visible }) => {
     income: '',
     portfolioSize: '',
     hasAdvisor: null,
-    switchReason: '',
+    switchReason: [],
     services: [],
     email: '',
     name: '',
@@ -73,6 +74,12 @@ const AdvisorForm: React.FC<AdvisorFormProps> = ({ visible }) => {
     }
   }, [currentStep]);
 
+  useEffect(() => {
+    if (currentStep > 1 && formRef.current) {
+      formRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [currentStep]);
+
   const validateCurrentStep = (): boolean => {
     let isValid = true;
     const newValidation = { ...validation };
@@ -96,7 +103,7 @@ const AdvisorForm: React.FC<AdvisorFormProps> = ({ visible }) => {
     } else if (currentStep === 8) {
       isValid = formData.hasAdvisor !== null;
     } else if (currentStep === 9) {
-      isValid = formData.switchReason !== '' || formData.hasAdvisor === false;
+      isValid = formData.switchReason.length > 0 || formData.hasAdvisor === false;
     } else if (currentStep === 10) {
       isValid = formData.services.length > 0;
     } else if (currentStep === 11) {
@@ -163,7 +170,7 @@ const AdvisorForm: React.FC<AdvisorFormProps> = ({ visible }) => {
       case 8:
         return formData.hasAdvisor === null;
       case 9:
-        return formData.hasAdvisor ? formData.switchReason === '' : false;
+        return formData.hasAdvisor ? formData.switchReason.length === 0 : false;
       case 10:
         return formData.services.length === 0;
       case 11:
@@ -216,8 +223,7 @@ const AdvisorForm: React.FC<AdvisorFormProps> = ({ visible }) => {
           (currentStep === 5 && newData.businessOwnership !== null) ||
           (currentStep === 6 && newData.income !== '') ||
           (currentStep === 7 && newData.portfolioSize !== '') ||
-          (currentStep === 8 && newData.hasAdvisor !== null) ||
-          (currentStep === 9 && newData.switchReason !== '')
+          (currentStep === 8 && newData.hasAdvisor !== null)
         ) {
           autoStep = currentStep + 1;
           if (currentStep === 8 && newData.hasAdvisor === false) {
@@ -361,7 +367,7 @@ const AdvisorForm: React.FC<AdvisorFormProps> = ({ visible }) => {
                 </p>
               </div>
               
-              <div className="bg-white p-8 rounded-xl shadow-lg border border-gray-100">
+              <div ref={formRef} className="bg-white p-8 rounded-xl shadow-lg border border-gray-100">
                 <FormProgress currentStep={currentStep} totalSteps={totalSteps} />
                 
                 <div className="mt-8 mb-10">

--- a/src/components/AdvisorForm/steps/Step9SwitchReason.tsx
+++ b/src/components/AdvisorForm/steps/Step9SwitchReason.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { ArrowRightLeft } from 'lucide-react';
+import { ArrowRightLeft, CheckSquare, SquareIcon } from 'lucide-react';
 
 interface Step9SwitchReasonProps {
-  value: string;
-  onChange: (value: string) => void;
+  value: string[];
+  onChange: (value: string[]) => void;
 }
 
 const Step9SwitchReason: React.FC<Step9SwitchReasonProps> = ({ value, onChange }) => {
@@ -17,6 +17,14 @@ const Step9SwitchReason: React.FC<Step9SwitchReasonProps> = ({ value, onChange }
     { id: 'other', label: 'Other reason' }
   ];
 
+  const toggleReason = (id: string) => {
+    if (value.includes(id)) {
+      onChange(value.filter(item => item !== id));
+    } else {
+      onChange([...value, id]);
+    }
+  };
+
   return (
     <div className="text-center">
       <div className="mx-auto w-16 h-16 bg-primary-100 rounded-full flex items-center justify-center mb-6">
@@ -24,22 +32,31 @@ const Step9SwitchReason: React.FC<Step9SwitchReasonProps> = ({ value, onChange }
       </div>
       <h3 className="text-2xl font-semibold text-primary-900 mb-4">Why are you considering a new advisor?</h3>
       <p className="text-secondary-600 mb-8">Understanding your needs helps us find an advisor who can better serve you.</p>
-      
+
       <div className="flex flex-col space-y-3 max-w-md mx-auto">
-        {options.map((option) => (
-          <button
-            key={option.id}
-            onClick={() => onChange(option.id)}
-            className={`py-4 px-6 rounded-lg border-2 transition duration-200 text-center ${
-              value === option.id
-                ? 'border-primary-600 bg-primary-50 text-primary-800'
-                : 'border-gray-300 hover:border-primary-300 hover:bg-primary-50'
-            }`}
-          >
-            <span className="text-base font-medium">{option.label}</span>
-          </button>
-        ))}
+        {options.map((option) => {
+          const isSelected = value.includes(option.id);
+          return (
+            <button
+              key={option.id}
+              onClick={() => toggleReason(option.id)}
+              className={`py-4 px-6 rounded-lg border-2 transition duration-200 text-left flex items-center ${
+                isSelected
+                  ? 'border-primary-600 bg-primary-50 text-primary-800'
+                  : 'border-gray-300 hover:border-primary-300 hover:bg-primary-50'
+              }`}
+            >
+              {isSelected ? (
+                <CheckSquare className="h-5 w-5 mr-3 text-primary-600 flex-shrink-0" />
+              ) : (
+                <SquareIcon className="h-5 w-5 mr-3 text-secondary-500 flex-shrink-0" />
+              )}
+              <span className="text-base font-medium">{option.label}</span>
+            </button>
+          );
+        })}
       </div>
+      <p className="mt-4 text-xs text-secondary-500">Select all that apply.</p>
     </div>
   );
 };

--- a/src/components/AdvisorForm/types.ts
+++ b/src/components/AdvisorForm/types.ts
@@ -7,7 +7,7 @@ export interface FormData {
   income: string;
   portfolioSize: string;
   hasAdvisor: boolean | null;
-  switchReason: string;
+  switchReason: string[];
   services: string[];
   email: string;
   name: string;


### PR DESCRIPTION
## Summary
- allow selecting multiple switch reasons with checkboxes
- keep the form section in view when navigating steps

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68418b98656c832ea9223fe46f424310