### PR TITLE
Fix routing and adjust CTA banner color

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/src/components/CtaBanner.tsx
+++ b/src/components/CtaBanner.tsx
@@ -15,7 +15,7 @@ const CtaBanner: React.FC<CtaBannerProps> = ({ onFindAdvisorClick }) => {
   return (
     <section 
       ref={ref}
-      className="py-16 md:py-20 bg-primary-900 relative overflow-hidden"
+      className="py-16 md:py-20 bg-primary-700 relative overflow-hidden"
     >
       {/* Background decorative elements */}
       <div className="absolute top-0 right-0 w-1/3 h-1/3 bg-primary-800 rounded-full filter blur-3xl opacity-50"></div>


### PR DESCRIPTION
## Summary
- add Netlify redirect config so `/find-advisor` loads correctly when accessed directly
- make the CTA banner use a slightly lighter background color for better contrast

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841a5429b04832e924a3d68a9529057