### PR TITLE
Refine hero copy and expand mistakes section

### DIFF
--- a/src/components/CostOfNoAdvice.tsx
+++ b/src/components/CostOfNoAdvice.tsx
@@ -11,18 +11,28 @@ const CostOfNoAdvice: React.FC = () => {
   const costs = [
     {
       icon: <TrendingDown className="h-8 w-8 text-red-500" />,
-      title: "Poor Investment Decisions",
-      description: "Without expert guidance, many individuals make emotionally-driven investment choices, often buying high and selling low."
+      title: "Poor Diversification",
+      description: "Tech stocks sank over 35% in 2022, leaving concentrated portfolios reeling. Diversifying helps reduce that risk."
     },
     {
       icon: <PiggyBank className="h-8 w-8 text-red-500" />,
-      title: "Missed Retirement Goals",
-      description: "Inadequate planning leads to insufficient savings and unrealistic expectations about retirement lifestyle."
+      title: "No Estate Plan",
+      description: "A 2023 survey found 73% of Americans lack an estate plan, putting their hard-earned assets at risk."
+    },
+    {
+      icon: <AlertTriangle className="h-8 w-8 text-red-500" />,
+      title: "Emotion-Driven Investing",
+      description: "Markets plunged 34% in early 2020 then quickly rebounded. Knee-jerk reactions can lock in losses."
+    },
+    {
+      icon: <DollarSign className="h-8 w-8 text-red-500" />,
+      title: "Undefined Goals",
+      description: "37% of adults tapped emergency savings last year. Clear objectives help keep plans on track."
     },
     {
       icon: <DollarSign className="h-8 w-8 text-red-500" />,
       title: "Tax Inefficiencies",
-      description: "Missing out on tax-advantaged strategies can cost thousands in unnecessary tax payments over your lifetime."
+      description: "Missing out on tax-advantaged strategies can cost thousands in unnecessary payments over your lifetime."
     },
     {
       icon: <AlertTriangle className="h-8 w-8 text-red-500" />,
@@ -49,7 +59,7 @@ const CostOfNoAdvice: React.FC = () => {
             </p>
           </div>
           
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
             {costs.map((cost, index) => (
               <div 
                 key={index}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -26,10 +26,10 @@ const Hero: React.FC<HeroProps> = ({ onFindAdvisorClick }) => {
         <div className="max-w-5xl mx-auto">
           <div className={`text-center transition duration-1000 ${inView ? 'opacity-100' : 'opacity-0 translate-y-10'}`}>
             <h1 className="font-serif text-4xl md:text-5xl lg:text-6xl font-bold text-primary-900 leading-tight mb-6">
-              Your Financial Goals Deserve the Right Advisor
+              Avoid Costly Mistakes &amp; Safeguard Your Wealth
             </h1>
             <p className="text-lg md:text-xl text-secondary-700 max-w-3xl mx-auto mb-10 leading-relaxed">
-              We match you with vetted advisors based on your unique financial needs and goals. Take the first step toward financial confidence today.
+              73% of Americans don&apos;t have an estate plan. Get matched with a vetted financial advisor who can help protect your assets and secure your future.
             </p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
               <button


### PR DESCRIPTION
## Summary
- update hero headline and subtext
- add stats-based mistakes to CostOfNoAdvice and switch to 3 columns

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68527421b974832e830c0826cfe3232b